### PR TITLE
Fix incorrect logic in bag exporter

### DIFF
--- a/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
@@ -48,7 +48,6 @@ struct Handler
 {
   std::shared_ptr<BaseHandler> handler;
   size_t current_index;
-  bool exported;
 };
 
 class BagExporter : public rclcpp::Node


### PR DESCRIPTION
- Avoid throwing an exception by adding a missing negation `!` in the 
  `handlers_["/tf_static"].handler->save_msg_to_file(0)` condition when 
   processing `tf_static` message
- Ensure that `CameraInfo` topics are evaluated only once by removing them from 
   the handlers after processing
   - Remove `exported` flag from `Handler` as no longer necessary