### PR TITLE
Add multiple rosbag extraction support

### DIFF
--- a/ros2_bag_exporter/README.md
+++ b/ros2_bag_exporter/README.md
@@ -89,8 +89,6 @@ topics:
     topic_dir: "transforms"
 ```
 
-<!-- - `bag_path`: The absolute path to the ROS 2 bag file you wish to export. -->
-
 #### Parameter Descriptions
 - `storage_id`: Specifies the storage format of the bag file. Common values include:
   - `mcap`: For MCAP storage format.

--- a/ros2_bag_exporter/README.md
+++ b/ros2_bag_exporter/README.md
@@ -56,7 +56,6 @@ The behavior of `ros2_bag_exporter` is controlled via a YAML configuration file.
 
 #### Configuration File Structure
 ```yaml
-output_dir: "/absolute/path/to/output/directory"
 storage_id: "mcap"  # Common storage ID; ensure it matches your bag's storage format
 topics:
   - name: "/camera/color/image_raw"
@@ -93,9 +92,7 @@ topics:
 <!-- - `bag_path`: The absolute path to the ROS 2 bag file you wish to export. -->
 
 #### Parameter Descriptions
-- `output_dir`: The absolute path to the directory where exported files will be saved.
 - `storage_id`: Specifies the storage format of the bag file. Common values include:
-  - `sqlite3`: Default storage for ROS 2 bags.
   - `mcap`: For MCAP storage format.
 - `topics`: A list of topics to export. Each topic requires:
   - `name`: The ROS 2 topic name.
@@ -106,15 +103,19 @@ topics:
 ### Run
 After building and sourcing the workspace, run the `bag_exporter` node using the following command:
 ```bash
-ros2 run ros2_bag_exporter bag_exporter --ros-args -p rosbag:=<path_to_rosbag.mcap> -p config_file:=<path_to_config>
+ros2 run ros2_bag_exporter bag_exporter --ros-args \
+  -p rosbags_directory:=<path_to_rosbags> \
+  -p output_directory:=<path_to_output> \
+  -p config_file:=<path_to_config>
 ```
 #### Command-Line Arguments
-- `rosbag`: The path to the ROS 2 bag file you wish to export. Only `.mcap` format is supported.
-- `config_file`: Specify a custom path to the YAML configuration file.
+- `rosbags_directory`: Path of the directory containing the rosbag splits. Only `.mcap` format is supported.
+- `output_directory`: Path of the directory where the exportation will be saved.
+- `config_file`: Path to the YAML configuration file.
 
 ### Output
 
-The extractor will generate an `export_metadata.yaml` file inside the `<output_dir>/<bag_name>` directory.
+The extractor will generate an `export_metadata.yaml` file inside the `<output_directory>/<bag_name>` directory.
 
 This metadata file provides details about synchronisation between camera images and point clouds, organised into a list of `sync_groups`. Additionally, the names of the original rosbags used will be saved under the `rosbags` field.
 

--- a/ros2_bag_exporter/README.md
+++ b/ros2_bag_exporter/README.md
@@ -56,7 +56,6 @@ The behavior of `ros2_bag_exporter` is controlled via a YAML configuration file.
 
 #### Configuration File Structure
 ```yaml
-bag_path: "/absolute/path/to/your/my_rosbag.mcap"
 output_dir: "/absolute/path/to/output/directory"
 storage_id: "mcap"  # Common storage ID; ensure it matches your bag's storage format
 topics:
@@ -91,8 +90,9 @@ topics:
     topic_dir: "transforms"
 ```
 
+<!-- - `bag_path`: The absolute path to the ROS 2 bag file you wish to export. -->
+
 #### Parameter Descriptions
-- `bag_path`: The absolute path to the ROS 2 bag file you wish to export.
 - `output_dir`: The absolute path to the directory where exported files will be saved.
 - `storage_id`: Specifies the storage format of the bag file. Common values include:
   - `sqlite3`: Default storage for ROS 2 bags.
@@ -106,10 +106,11 @@ topics:
 ### Run
 After building and sourcing the workspace, run the `bag_exporter` node using the following command:
 ```bash
-ros2 run ros2_bag_exporter bag_exporter --ros-args -p config_file:=<path_to_config>
+ros2 run ros2_bag_exporter bag_exporter --ros-args -p rosbag:=<path_to_rosbag.mcap> -p config_file:=<path_to_config>
 ```
 #### Command-Line Arguments
-- `<path_to_config>`: Specify a custom path to the YAML configuration file.
+- `rosbag`: The path to the ROS 2 bag file you wish to export. Only `.mcap` format is supported.
+- `config_file`: Specify a custom path to the YAML configuration file.
 
 ### Output
 

--- a/ros2_bag_exporter/config/exporter_config.yaml
+++ b/ros2_bag_exporter/config/exporter_config.yaml
@@ -1,8 +1,5 @@
 # Configuration for processing ROS2 bag files
-# This file specifies the paths, storage format, and topics to extract from the ROS bag.
-
-# Directory where the exported data will be saved
-output_dir: "/path/to/output_directory"
+# This file specifies the storage format, and topics to extract from the ROS bag.
 
 # Storage format for the exported data. Options are "sqlite3" or "mcap"
 storage_id: "mcap"

--- a/ros2_bag_exporter/config/exporter_config.yaml
+++ b/ros2_bag_exporter/config/exporter_config.yaml
@@ -1,9 +1,6 @@
 # Configuration for processing ROS2 bag files
 # This file specifies the paths, storage format, and topics to extract from the ROS bag.
 
-# Path to the input ROS2 bag file
-bag_path: "/path/to/your.bag"
-
 # Directory where the exported data will be saved
 output_dir: "/path/to/output_directory"
 

--- a/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
@@ -56,9 +56,10 @@ class BagExporter : public rclcpp::Node
 {
 public:
   explicit BagExporter(const rclcpp::NodeOptions & options);
+  bool run();
 
 private:
-  void load_configuration(const std::string & config_file);
+  void load_configuration();
   void setup_handlers(const fs::path & output_directory_path);
   void extract_data(const fs::path & rosbag);
   void export_data(const fs::path & used_rosbag, const fs::path & output_directoy_path);
@@ -67,6 +68,7 @@ private:
   size_t global_id_;
   std::string rosbags_directory_;
   std::string output_directory_;
+  std::string config_file_;
   std::string storage_id_;
   std::string rosbag_base_name_;
   std::vector<TopicConfig> topics_;

--- a/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
@@ -60,8 +60,8 @@ public:
 private:
   void load_configuration(const std::string & config_file);
   void setup_handlers(const fs::path & output_directory_path);
-  void export_bag(const fs::path & rosbag);
-  void create_metadata_file(const fs::path & used_rosbag, const fs::path & output_directoy_path);
+  void extract_data(const fs::path & rosbag);
+  void export_data(const fs::path & used_rosbag, const fs::path & output_directoy_path);
   void process_rosbag_directory();
 
   size_t global_id_;

--- a/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
@@ -50,6 +50,8 @@ struct Handler
   size_t current_index;
 };
 
+namespace fs = std::filesystem;
+
 class BagExporter : public rclcpp::Node
 {
 public:
@@ -57,14 +59,14 @@ public:
 
 private:
   void load_configuration(const std::string & config_file);
-  void setup_handlers();
-  void export_bag();
-  void create_metadata_file();
+  void setup_handlers(const fs::path & output_directory_path);
+  void export_bag(const fs::path & rosbag);
+  void create_metadata_file(const fs::path & used_rosbag, const fs::path & output_directoy_path);
+  void process_rosbag_directory();
 
-  bool tf_extracted_;
-  bool all_cameras_info_extracted_;
-  std::string bag_path_;
-  std::string output_dir_;
+  size_t global_id_;
+  std::string rosbags_directory_;
+  std::string output_directory_;
   std::string storage_id_;
   std::string rosbag_base_name_;
   std::vector<TopicConfig> topics_;

--- a/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
@@ -6,17 +6,23 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <limits>
+#include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 // ANSI escape codes for colourised terminal output
 #define COLOR_RESET "\033[0m"
+#define GREEN_LOG "\033[32m"
 #define MAGENTA_LOG "\033[35m"
 #define BOLD_LOG "\033[1m"
 #define CYAN_LOG "\033[36m"
+#define YELLOW_LOG "\033[33m"
+#define UNDERLINE_LOG "\033[4m"
 
-namespace rosbag2_exporter
+namespace rosbag2_exporter::utils
 {
 
 std::string get_cam_name(const std::string & path)
@@ -103,6 +109,83 @@ void print_progress(int percentage)
   if (percentage >= 100) std::cout << std::endl;
 }
 
-}  // namespace rosbag2_exporter
+/**
+ * @brief Find and return all .mcap file paths in a directory, sorted by index.
+ *
+ * Looks for files with names ending in "_<index>.mcap" and returns them
+ * sorted numerically by their index value.
+ *
+ * @param rosbag_directory Path to the folder containing .mcap files.
+ * @return A vector of sorted .mcap file paths.
+ */
+std::vector<fs::path> find_rosbags(const fs::path & rosbag_directory)
+{
+  if (!fs::is_directory(rosbag_directory)) return {};
+
+  std::regex pattern(R"(.*_(\d+)\.mcap)");
+  std::vector<std::pair<int, fs::path>> indexed;
+
+  for (const auto & entry : fs::directory_iterator(rosbag_directory)) {
+    if (!entry.is_regular_file()) continue;
+    std::smatch match;
+    std::string name = entry.path().filename().string();
+    if (std::regex_match(name, match, pattern))
+      indexed.emplace_back(std::stoi(match[1]), entry.path());
+  }
+
+  std::sort(indexed.begin(), indexed.end());
+
+  std::vector<fs::path> sorted;
+  for (auto & [_, path] : indexed) sorted.push_back(path);
+  return sorted;
+}
+
+/**
+ * @brief Create a new name based on the original rosbag directory name.
+ *
+ * The original name is expected to be in the format:
+ *      <timestamp>_<rosbag_name>/
+ * where <timestamp> is in the format YYYY_MM_DD-HH_MM_SS,
+ * and <rosbag_name> is the name of the recording.
+ *
+ * The new name is created by swapping the timestamp and recording name.
+ * Example: 2025_03_25-12_47_53_arthurs_seat_loop
+ * becomes: arthurs_seat_loop_2025_03_25-12_47_53
+ *
+ * @param rosbag_directory The path to the original rosbag directory.
+ * @return The new name for the directory.
+ */
+std::string get_new_name(const fs::path & rosbag_directory)
+{
+  constexpr size_t timestamp_char_length = 19;
+  std::string base_name = rosbag_directory.stem().string();
+  std::string timestamp = base_name.substr(0, timestamp_char_length);
+  std::string route_name =
+    base_name.substr(timestamp_char_length + 1, base_name.size() - timestamp_char_length + 1);
+  std::string new_name = route_name + "_" + timestamp;
+  return new_name;
+}
+
+/**
+ * @brief Get the rosbag index from the its filename.
+ *
+ * The filename is expected to be in the format:
+ *      <name>_<index>.mcap
+ * @param rosbag_path The path to the rosbag file.
+ * @return The index extracted from the filename.
+ */
+size_t get_rosbag_index(const fs::path & rosbag_path)
+{
+  std::string base_name = rosbag_path.stem().string();
+  size_t index = base_name.find_last_of('_');
+  size_t dot_index = base_name.find_last_of('.');
+  if (index == std::string::npos) {
+    throw std::runtime_error(
+      "Invalid rosbag filename format. Expected format: <name>_<index>.mcap");
+  }
+  return std::stoul(base_name.substr(index + 1, dot_index - index - 1));
+}
+
+}  // namespace rosbag2_exporter::utils
 
 #endif  // ROSBAG2_EXPORTER__UTILS_HPP_

--- a/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
@@ -84,9 +84,13 @@ void print_progress(int percentage)
   static int last_percentage = -1;
 
   // Never exceeds 100%
-  if (percentage > 100) percentage = 100;
+  if (percentage > 100) {
+    percentage = 100;
+  }
   // Prevent duplicate prints
-  if (percentage == last_percentage) return;
+  if (percentage == last_percentage) {
+    return;
+  }
 
   last_percentage = percentage;
 
@@ -95,18 +99,21 @@ void print_progress(int percentage)
 
   std::cout << "\r\t\t\t\t\t\t [";
   for (int i = 0; i < width; ++i) {
-    if (i < pos)
+    if (i < pos) {
       std::cout << "=";
-    else if (i == pos)
+    } else if (i == pos) {
       std::cout << ">";
-    else
+    } else {
       std::cout << " ";
+    }
   }
 
   std::cout << "] " << percentage << "%" << std::flush;
 
   // Print a newline once at 100%
-  if (percentage >= 100) std::cout << std::endl;
+  if (percentage >= 100) {
+    std::cout << std::endl;
+  }
 }
 
 /**
@@ -120,23 +127,26 @@ void print_progress(int percentage)
  */
 std::vector<fs::path> find_rosbags(const fs::path & rosbag_directory)
 {
-  if (!fs::is_directory(rosbag_directory)) return {};
-
   std::regex pattern(R"(.*_(\d+)\.mcap)");
   std::vector<std::pair<int, fs::path>> indexed;
 
   for (const auto & entry : fs::directory_iterator(rosbag_directory)) {
-    if (!entry.is_regular_file()) continue;
+    if (!entry.is_regular_file()) {
+      continue;
+    }
     std::smatch match;
     std::string name = entry.path().filename().string();
-    if (std::regex_match(name, match, pattern))
+    if (std::regex_match(name, match, pattern)) {
       indexed.emplace_back(std::stoi(match[1]), entry.path());
+    }
   }
 
   std::sort(indexed.begin(), indexed.end());
 
   std::vector<fs::path> sorted;
-  for (auto & [_, path] : indexed) sorted.push_back(path);
+  for (auto & [_, path] : indexed) {
+    sorted.push_back(path);
+  }
   return sorted;
 }
 

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -30,7 +30,15 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
     return;
   }
 
-  // Declare and get the config_file parameter (absolute path)
+  // Get parameters
+  bag_path_ = this->declare_parameter<std::string>("rosbag", "/my/path/to/rosbag.mcap");
+
+  if (std::filesystem::is_directory(bag_path_)) {
+    RCLCPP_ERROR(this->get_logger(), "The provided path is a directory, not a file.");
+    rclcpp::shutdown();
+    return;
+  }
+
   std::string config_file = this->declare_parameter<std::string>(
     "config_file", package_share_directory + "/config/exporter_config.yaml");
 
@@ -61,7 +69,6 @@ void BagExporter::load_configuration(const std::string & config_file)
     RCLCPP_INFO(this->get_logger(), "Loading config from: %s", config_file.c_str());
 
     YAML::Node config = YAML::LoadFile(config_file);
-    bag_path_ = config["bag_path"].as<std::string>();
     output_dir_ = config["output_dir"].as<std::string>();
     storage_id_ = config["storage_id"].as<std::string>();
 

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -154,7 +154,7 @@ void BagExporter::setup_handlers(const fs::path & output_directory_path)
     }
   }
 }
-void BagExporter::export_bag(const fs::path & rosbag)
+void BagExporter::extract_data(const fs::path & rosbag)
 {
   // Initialize reader
   rosbag2_cpp::readers::SequentialReader reader;
@@ -297,7 +297,7 @@ void BagExporter::export_bag(const fs::path & rosbag)
   }
 }
 
-void BagExporter::create_metadata_file(
+void BagExporter::export_data(
   const fs::path & used_rosbag, const fs::path & output_directoy_path)
 {
   // YAML C++ preserves list order, so topics_[0] corresponds to
@@ -428,9 +428,9 @@ void BagExporter::process_rosbag_directory()
 
     setup_handlers(split_export_directory);
 
-    export_bag(rosbag);
+    extract_data(rosbag);
 
-    create_metadata_file(rosbag, split_export_directory);
+    export_data(rosbag, split_export_directory);
   }
 
   RCLCPP_INFO(

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -155,7 +155,7 @@ void BagExporter::extract_data(const fs::path & rosbag)
 
       // Only one camera info message will be saved per topic
       if (cam_info_topic_it != cam_info_topics_.end()) {
-        total_bag_messages += 1;
+        ++total_bag_messages;
       } else {
         total_bag_messages += it->message_count;
       }
@@ -188,8 +188,8 @@ void BagExporter::extract_data(const fs::path & rosbag)
           tf_extracted = true;
         }
 
-        global_id_ += 1;
-        progress++;
+        ++global_id_;
+        ++progress;
         continue;
       }
 
@@ -210,14 +210,14 @@ void BagExporter::extract_data(const fs::path & rosbag)
           }
 
           // Increase counter
-          camera_info_extracted_n += 1;
+          ++camera_info_extracted_n;
 
           // Remove this camera info handler so we do not
           // evaluate this topic again
           handler_it->second.handler.reset();
 
-          global_id_ += 1;
-          progress++;
+          ++global_id_;
+          ++progress;
 
           // Check if we are done with all the camera info messages
           if (camera_info_extracted_n == cam_info_topics_.size()) {
@@ -249,9 +249,9 @@ void BagExporter::extract_data(const fs::path & rosbag)
         RCLCPP_WARN(this->get_logger(), "No configuration found for topic: %s", topic.c_str());
       }
 
-      handler_it->second.current_index++;
-      global_id_++;
-      progress++;
+      ++handler_it->second.current_index;
+      ++global_id_;
+      ++progress;
 
       // Log progress
       utils::print_progress(static_cast<int>(std::round((progress * 100.0) / total_bag_messages)));
@@ -289,7 +289,7 @@ void BagExporter::export_data(const fs::path & used_rosbag, const fs::path & out
     sync_group["id"] = sync_group_id;
     sync_group["stamp"]["sec"] = main_data_meta.timestamp.sec;
     sync_group["stamp"]["nanosec"] = main_data_meta.timestamp.nanosec;
-    sync_group["lidar"]["global_id_"] = main_data_meta.global_id;
+    sync_group["lidar"]["global_id"] = main_data_meta.global_id;
 
     // Save this pointcloud
     if (!main_sensor_handler->save_msg_to_file(idx)) {
@@ -308,7 +308,7 @@ void BagExporter::export_data(const fs::path & used_rosbag, const fs::path & out
     YAML::Node cameras;
 
     // Find closest timestamp for each camera
-    for (int k = 0; k < topics_.size(); k++) {
+    for (int k = 0; k < topics_.size(); ++k) {
       // Only process camera messages
       if (
         topics_[k].type != MessageType::Image && topics_[k].type != MessageType::CompressedImage) {
@@ -324,13 +324,13 @@ void BagExporter::export_data(const fs::path & used_rosbag, const fs::path & out
       // Create YAML metadata based on the found time index
       auto current_cam_meta = current_meta_data_vec[closest_time_index];
       YAML::Node cam;
-      cam["global_id_"] = current_cam_meta.global_id;
+      cam["global_id"] = current_cam_meta.global_id;
       cam["name"] = utils::get_cam_name(topics_[k].name);
 
       // Save this image
       if (!curr_cam_handler->save_msg_to_file(closest_time_index)) {
         throw std::runtime_error(
-          "Unable to save image msg as file, global_id_: " +
+          "Unable to save image msg as file, global_id: " +
           std::to_string(main_data_meta.global_id));
       }
 

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -208,6 +208,7 @@ void BagExporter::extract_data(const fs::path & rosbag)
   size_t camera_info_extracted_n = 0;
   bool all_cameras_info_extracted = false;
   bool tf_extracted = false;
+  int progress = 0;
 
   // Read and process messages
   while (reader.has_next()) {
@@ -229,6 +230,7 @@ void BagExporter::extract_data(const fs::path & rosbag)
         }
 
         global_id_ += 1;
+        progress++;
         continue;
       }
 
@@ -256,6 +258,7 @@ void BagExporter::extract_data(const fs::path & rosbag)
           handler_it->second.handler.reset();
 
           global_id_ += 1;
+          progress++;
 
           // Check if we are done with all the camera info messages
           if (camera_info_extracted_n == cam_info_topics_.size()) {
@@ -289,16 +292,15 @@ void BagExporter::extract_data(const fs::path & rosbag)
 
       handler_it->second.current_index++;
       global_id_++;
+      progress++;
 
       // Log progress
-      utils::print_progress(
-        static_cast<int>(std::round((global_id_ * 100.0) / total_bag_messages)));
+      utils::print_progress(static_cast<int>(std::round((progress * 100.0) / total_bag_messages)));
     }
   }
 }
 
-void BagExporter::export_data(
-  const fs::path & used_rosbag, const fs::path & output_directoy_path)
+void BagExporter::export_data(const fs::path & used_rosbag, const fs::path & output_directoy_path)
 {
   // YAML C++ preserves list order, so topics_[0] corresponds to
   // the first sensor defined in the YAML file, used as the time sync reference.

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -42,6 +42,9 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
   std::string config_file = this->declare_parameter<std::string>(
     "config_file", package_share_directory + "/config/exporter_config.yaml");
 
+  // Use rosbag parent directory as base to save exported files
+  output_dir_ = std::filesystem::path(bag_path_).parent_path().string() + "/exported_data";
+
   // Load configuration
   load_configuration(config_file);
 
@@ -69,7 +72,6 @@ void BagExporter::load_configuration(const std::string & config_file)
     RCLCPP_INFO(this->get_logger(), "Loading config from: %s", config_file.c_str());
 
     YAML::Node config = YAML::LoadFile(config_file);
-    output_dir_ = config["output_dir"].as<std::string>();
     storage_id_ = config["storage_id"].as<std::string>();
 
     RCLCPP_INFO(


### PR DESCRIPTION
- Change `rosbag` param to `rosbags_directory` to explicitly
  mention that the input should be a directory
  - Throw an exception if it is not a directory
- Add `output_directory` ros param to define the exportation
   destination path
- Add `process_rosbag_directory()` member function to scope the
  multi rosbag exporation logic
  - Name export directories with the recording name first
  - Find all the rosbag files inside the directory and export each file
    individually
  - Keep `global_id` for each data message recording level rather than
    split level.
  - Modify `setup_handlers()`, `export_bag()` and
    `create_metadata_file()` functions so they adapt to a specific
    rosbag file.
- Add `find_rosbags()`, `get_new_name()` and `get_rosbag_index()`
  utilities functions and add a `utils` namespace.
- Modify logs to reduce terminal cluttering and provide a better format.

- Ensure the exporter returns consistent exit codes
  - Removed scattered `return` statements and unnecessary 
    `try-catch` blocks to centralise error handling in the
    top-level function.
    - Add `run()` function and move the running logic from 
      class constructor to it, so returns can be implemented
    - Make `config_file` a class member and avoid receiving an
      argument when calling `load_configuration`
  - Ensured alignment with CLI conventions: 
    return `0` on success, `1` on failure.

- Rename functions to align better with their purpose
   - Rename `export_bag()` to `extract_data()`
   - Rename `create_metadata_file()` to `export_data()`
 
- Update README
