### PR TITLE
Remove ANSI colour codes from result log

### DIFF
--- a/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
@@ -15,7 +15,6 @@
 
 // ANSI escape codes for colourised terminal output
 #define COLOR_RESET "\033[0m"
-#define GREEN_LOG "\033[32m"
 #define MAGENTA_LOG "\033[35m"
 #define BOLD_LOG "\033[1m"
 #define CYAN_LOG "\033[36m"

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -394,9 +394,7 @@ void BagExporter::process_rosbag_directory()
     export_data(rosbag, split_export_directory);
   }
 
-  RCLCPP_INFO(
-    this->get_logger(), "🚀 Data exported in: " GREEN_LOG "%s" COLOR_RESET,
-    new_output_dir.string().c_str());
+  RCLCPP_INFO(this->get_logger(), "🚀 Data exported in: %s", new_output_dir.string().c_str());
 }
 
 bool BagExporter::run()


### PR DESCRIPTION
- Colour codes were causing issues for scripts 
  reading stdout to get the export directory.
