### PR TITLE
Export the tf message with the most transforms.

### DIFF
--- a/ros2_bag_exporter/README.md
+++ b/ros2_bag_exporter/README.md
@@ -85,7 +85,7 @@ topics:
     topic_dir: "lidar"
   - name: "/tf_static"
     type: "TF"
-    sample_interval: 0   # Not used for this type
+    sample_interval: 1   # Process every message
     topic_dir: "transforms"
 ```
 
@@ -96,6 +96,8 @@ topics:
   - `name`: The ROS 2 topic name.
   - `type`: The message type (`PointCloud2`, `Image`, `CompressedImage`,`CameraInfo`,`IMU`, `GPS` and `TF`).
   - `sample_interval`: The interval at which messages will be exported (e.g., 1 for every 2 messages).
+    - For the`TF` type, this works a bit differently: every `sample_interval` message is processed, but only the
+      one containing the most transforms will be exported (see [#19](https://github.com/ipab-rad/tartan_rosbag_exporter/issues/17)).
   - `topic_dir`: The name of the directory where the sensor data from the topic will be saved. The directory is created in `<output_dir>/<bag_name>/`.
 
 ### Run

--- a/ros2_bag_exporter/config/exporter_config.yaml
+++ b/ros2_bag_exporter/config/exporter_config.yaml
@@ -47,5 +47,5 @@ topics:
   # Configuration for the TF topic (exported only once)
   - name: "/tf_static"          # Name of the topic to extract
     type: "TF"                  # Data type of the topic
-    sample_interval: 0          # Not used for this type
+    sample_interval: 1          # Process every message
     topic_dir: "extrinsics"     # Output data in <output_dir>/<bag_name>/extrinsics

--- a/ros2_bag_exporter/include/rosbag2_exporter/handlers/tf_handler.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/handlers/tf_handler.hpp
@@ -53,10 +53,10 @@ public:
       return false;
     }
 
-    // Get the Tf2 message that contains the highest
-    // number of transformations and create the YAML structure from it
-    auto tf_msg_map_element = tranformations_count_map_.rbegin();
-    YAML::Node yaml_root = create_yaml(tf_msg_map_element->second);
+    // Get the map pair with the TF message containing the most transformations
+    // Use a reverse iterator (rbegin) to access the entry with the largest key
+    auto max_tfs_map_pair = tranformations_count_map_.rbegin();
+    YAML::Node yaml_root = create_yaml(max_tfs_map_pair->second);
 
     // Serialise the YAML node to a string
     YAML::Emitter out;

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -188,6 +188,9 @@ void BagExporter::extract_data(const fs::path & rosbag)
           rclcpp::SerializedMessage ser_msg(*serialized_msg->serialized_data);
 
           cam_info_handler.handler->process_message(ser_msg, global_id_);
+          // TODO(hector): CameraInfoHandler doesn’t track message indices, as it’s meant to
+          //       export only one. Index 0 is passed because save_msg_to_file requires it.
+          //       This should be addressed in #21.
           if (!cam_info_handler.handler->save_msg_to_file(0)) {
             throw std::runtime_error("Failed to save camera info message to file");
           }
@@ -338,6 +341,9 @@ void BagExporter::export_data(const fs::path & used_rosbag, const fs::path & out
   // Export tf_static if we have extracted it
   if (handlers_.find("/tf_static") != handlers_.end() && handlers_["/tf_static"].handler) {
     if (!handlers_["/tf_static"].handler->save_msg_to_file(0)) {
+      // TODO(hector): TFHandler doesn’t track message indices, as it’s meant to
+      //       export only one. Index 0 is passed because save_msg_to_file requires it.
+      //       This should be addressed in #21.
       throw std::runtime_error("Unable to save tf_static message to a file ");
     }
   }


### PR DESCRIPTION
- Fix extracting the wrong tf_static message if multiple and different
  are present in the bag file. This assumes that the most relevant
  tf_static message is the one with the most transforms. #17 
- Modify `TFHandler` to:
  - Save each `TFMessage` with its associated
  transformation count in a sorted map when `process_message()`
  is called
  - Get the `TFMessage` with the most transforms from the sorted map
    when `save_msg_to_file()` is called
- Modify `BagExporter` to:
  - Call the TF's handler `save_msg_to_file()` method in `export_bag()`
    if a `TFHandler` was registered
  - Remove old tf extraction logic in `export_bag()`
- Ensure `sample_interval` is not zero for `TF` in `export_config.yaml`
  to avoid zero division errors.
- Update README to clarify this behaviour.