### PR TITLE
Add support for Nebula HESAI LIDAR points

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ If you plan to modify this package, use `dev.sh` instead to run docker container
 
 ```bash
 ./dev.sh -p <rosbags_directory> -o <exported_data_directory>
-
-# rosbag_expoter@<your_machine>:/opt/ros_ws$ colcon_build
-# Starting >>> ros2_bag_exporter
-# Finished <<< ros2_bag_exporter [15.7s]
-#
-# Summary: 1 package finished [16.4s]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,52 @@ The repository includes tools and a Docker environment for reading and exporting
 
 For general-purpose functionality, please refer to the original repository linked above.
 
-## Packages
-
-- [ros2_bag_exporter](./ros2_bag_exporter/README.md)
-
 ## Usage
 
-TODO
+### Build and run the Docker container
+
+To build and run the Docker container interactively, use:
+
+```bash
+./runtime.sh -p <rosbags_directory> -o <exported_data_directory>
+```
+
+where:
+
+- `<rosbags_directory>`: Parent directory containing your ROS bags recordings
+- `<exported_data_directory>`: Parent directory where the data is/will be exported.
+
+The input directories will be mounted in `/opt/ros_ws/rosbags` and `/opt/ros_ws/exported_data` in the container respectively.
+
+### Export your ROS bags
+
+Once inside the Docker container, run the following command:
+
+```bash
+cd /opt/ros_ws
+
+ros2 run ros2_bag_exporter bag_exporter --ros-args \
+  -p rosbags_directory:=./rosbags/<my_recording_directory> \
+  -p output_directory:=./exported_data \
+  -p config_file:=./config/av_sensor_export_config.yaml
+```
+
+You will find the exported data inside a directory in `/opt/ros_ws/exported_data`. Please see [ros2_bag_exporter](./ros2_bag_exporter/README.md) for further reference.
+
+### Run in development mode
+
+If you plan to modify this package, use `dev.sh` instead to run docker container in development mode. The `ros2_bag_exporter` package will be mounted in `/opt/ros_ws/src` automatically and an alias `colcon_build` will be available for compilation.
+
+```bash
+./dev.sh -p <rosbags_directory> -o <exported_data_directory>
+
+# rosbag_expoter@<your_machine>:/opt/ros_ws$ colcon_build
+# Starting >>> ros2_bag_exporter
+# Finished <<< ros2_bag_exporter [15.7s]
+#
+# Summary: 1 package finished [16.4s]
+```
+
 
 ## License
 This project is licensed under the Apache License 2.0.

--- a/dev.sh
+++ b/dev.sh
@@ -9,19 +9,23 @@ CYCLONE_VOL=""
 CYCLONE_DIR=/home/$USER/cyclone_dds.xml
 # Default in-vehicle rosbags directory
 ROSBAGS_DIR=/recorded_datasets/edinburgh
+# Default export directory
+EXPORT_DIR=/mnt/vdb/exported_data
 # Default value for headless
 headless=false
 
 # Function to print usage
 usage() {
     echo "
-Usage: dev.sh [-l|--local] [--path | -p ] [--headless] [--help | -h]
+Usage: dev.sh [-l|--local] [--path | -p ] [--output | -o ] [--headless] [--help | -h]
 
 Options:
     -l | --local    Use default local cyclone_dds.xml config
                     Optionally point to absolute -l /path/to/cyclone_dds.xml
     -p | --path     ROSBAGS_DIR_PATH
                     Specify path to store recorded rosbags
+    -o | --output   EXPORT_DIR
+                    Specify path where exported data is stored
     --headless      Run the Docker image without X11 forwarding
     -h | --help     Display this help message and exit.
     "
@@ -41,6 +45,15 @@ while [[ "$#" -gt 0 ]]; do
         -p|--path)
             if [[ -n "$2" && "$2" != -* ]]; then
                 ROSBAGS_DIR="$2"
+                shift
+            else
+                echo "Error: Argument for $1 is missing."
+                usage
+            fi
+            ;;
+        -o|--output)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                EXPORT_DIR="$2"
                 shift
             else
                 echo "Error: Argument for $1 is missing."
@@ -72,6 +85,12 @@ if [ ! -d "$ROSBAGS_DIR" ]; then
     exit 1
 fi
 
+# Verify EXPORT_DIR exists
+if [ ! -d "$EXPORT_DIR" ]; then
+    echo "$EXPORT_DIR does not exist! Please provide a valid path where exported data is stored"
+    exit 1
+fi
+
 
 MOUNT_X=""
 if [ "$headless" = "false" ]; then
@@ -89,7 +108,6 @@ docker build \
 
 # Get the absolute path of the script
 SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-mkdir -p $SCRIPT_DIR/output
 
 # Run docker image with local code volumes for development
 docker run -it --rm --net host --privileged \
@@ -101,7 +119,7 @@ docker run -it --rm --net host --privileged \
     -v /tmp:/tmp \
     $CYCLONE_VOL \
     -v $ROSBAGS_DIR:/opt/ros_ws/rosbags \
-    -v $SCRIPT_DIR/output:/opt/ros_ws/output \
+    -v $EXPORT_DIR:/opt/ros_ws/exported_data \
     -v $SCRIPT_DIR/ros2_bag_exporter:/opt/ros_ws/src/ros2_bag_exporter \
     -v /etc/localtime:/etc/localtime:ro \
     tartan_rosbag_expoter:latest-dev

--- a/ros2_bag_exporter/config/av_sensor_export_config.yaml
+++ b/ros2_bag_exporter/config/av_sensor_export_config.yaml
@@ -5,15 +5,15 @@ storage_id: "mcap"
 # List of topics to extract from the ROS2 bag
 topics:
   # Configuration for Pointclouds, defined first to use their timestamp for sensor sync
-  - name: "/sensor/lidar/top/points"  # 10Hz
+  - name: "/sensor/lidar/top/points"
     type: "PointCloud2"
-    sample_interval: 1                # 10Hz
+    sample_interval: 1
     topic_dir: "lidar/top"
 
   # Configuration for Compressed Images
-  - name: "/sensor/camera/fsp_l/image_rect_color/compressed"   # 20Hz
+  - name: "/sensor/camera/fsp_l/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/fsp_l"
 
   - name: "/sensor/camera/fsp_l/camera_info"
@@ -21,9 +21,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/fsp_l"
 
-  - name: "/sensor/camera/fsp_r/image_rect_color/compressed"   # 20Hz
+  - name: "/sensor/camera/fsp_r/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/fsp_r"
 
   - name: "/sensor/camera/fsp_r/camera_info"
@@ -31,9 +31,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/fsp_r"
 
-  - name: "/sensor/camera/rsp_l/image_rect_color/compressed"   # 20Hz
+  - name: "/sensor/camera/rsp_l/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/rsp_l"
 
   - name: "/sensor/camera/rsp_l/camera_info"
@@ -41,9 +41,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/rsp_l"
 
-  - name: "/sensor/camera/rsp_r/image_rect_color/compressed"   # 20Hz
+  - name: "/sensor/camera/rsp_r/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/rsp_r"
 
   - name: "/sensor/camera/rsp_r/camera_info"
@@ -51,9 +51,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/rsp_r"
 
-  - name: "/sensor/camera/lspf_r/image_rect_color/compressed"  # 20Hz
+  - name: "/sensor/camera/lspf_r/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/lspf_r"
 
   - name: "/sensor/camera/lspf_r/camera_info"
@@ -61,9 +61,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/lspf_r"
 
-  - name: "/sensor/camera/lspr_l/image_rect_color/compressed"  # 20Hz
+  - name: "/sensor/camera/lspr_l/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/lspr_l"
 
   - name: "/sensor/camera/lspr_l/camera_info"
@@ -71,9 +71,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/lspr_l"
 
-  - name: "/sensor/camera/rspf_l/image_rect_color/compressed"  # 20Hz
+  - name: "/sensor/camera/rspf_l/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 10Hz
+    sample_interval: 1
     topic_dir: "camera/rspf_l"
 
   - name: "/sensor/camera/rspf_l/camera_info"
@@ -81,9 +81,9 @@ topics:
     sample_interval: 0
     topic_dir: "camera/rspf_l"
 
-  - name: "/sensor/camera/rspr_r/image_rect_color/compressed"  # 20Hz
+  - name: "/sensor/camera/rspr_r/image_rect_color/compressed"
     type: "CompressedImage"
-    sample_interval: 1                                         # 20Hz
+    sample_interval: 1
     topic_dir: "camera/rspr_r"
 
   - name: "/sensor/camera/rspr_r/camera_info"

--- a/ros2_bag_exporter/config/av_sensor_export_config.yaml
+++ b/ros2_bag_exporter/config/av_sensor_export_config.yaml
@@ -1,0 +1,97 @@
+# Configuration for processing ROS2 bag files
+
+storage_id: "mcap"
+
+# List of topics to extract from the ROS2 bag
+topics:
+  # Configuration for Pointclouds, defined first to use their timestamp for sensor sync
+  - name: "/sensor/lidar/top/points"  # 10Hz
+    type: "PointCloud2"
+    sample_interval: 1                # 10Hz
+    topic_dir: "lidar/top"
+
+  # Configuration for Compressed Images
+  - name: "/sensor/camera/fsp_l/image_rect_color/compressed"   # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/fsp_l"
+
+  - name: "/sensor/camera/fsp_l/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/fsp_l"
+
+  - name: "/sensor/camera/fsp_r/image_rect_color/compressed"   # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/fsp_r"
+
+  - name: "/sensor/camera/fsp_r/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/fsp_r"
+
+  - name: "/sensor/camera/rsp_l/image_rect_color/compressed"   # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/rsp_l"
+
+  - name: "/sensor/camera/rsp_l/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/rsp_l"
+
+  - name: "/sensor/camera/rsp_r/image_rect_color/compressed"   # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/rsp_r"
+
+  - name: "/sensor/camera/rsp_r/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/rsp_r"
+
+  - name: "/sensor/camera/lspf_r/image_rect_color/compressed"  # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/lspf_r"
+
+  - name: "/sensor/camera/lspf_r/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/lspf_r"
+
+  - name: "/sensor/camera/lspr_l/image_rect_color/compressed"  # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/lspr_l"
+
+  - name: "/sensor/camera/lspr_l/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/lspr_l"
+
+  - name: "/sensor/camera/rspf_l/image_rect_color/compressed"  # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 10Hz
+    topic_dir: "camera/rspf_l"
+
+  - name: "/sensor/camera/rspf_l/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/rspf_l"
+
+  - name: "/sensor/camera/rspr_r/image_rect_color/compressed"  # 20Hz
+    type: "CompressedImage"
+    sample_interval: 1                                         # 20Hz
+    topic_dir: "camera/rspr_r"
+
+  - name: "/sensor/camera/rspr_r/camera_info"
+    type: "CameraInfo"
+    sample_interval: 0
+    topic_dir: "camera/rspr_r"
+
+  - name: "/tf_static"
+    type: "TF"
+    sample_interval: 1
+    topic_dir: "extrinsics"

--- a/ros2_bag_exporter/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
@@ -8,6 +8,7 @@
 
 #include "rclcpp/logging.hpp"
 #include "rosbag2_exporter/handlers/base_handler.hpp"
+#include "rosbag2_exporter/point_types.hpp"
 
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
@@ -74,9 +75,9 @@ public:
 
     // Create the point cloud, convert the ROS message, and save it
     if (has_intensity) {
-      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+      pcl::PointCloud<NebulaPoint>::Ptr cloud(new pcl::PointCloud<NebulaPoint>);
       pcl::fromROSMsg(pc2_msg, *cloud);
-      return save_pointcloud_to_file<pcl::PointXYZI>(cloud, data_meta.data_path);
+      return save_pointcloud_to_file<NebulaPoint>(cloud, data_meta.data_path);
     } else {
       throw std::invalid_argument("The pointcloud message should have an 'intensity' field!");
     }

--- a/ros2_bag_exporter/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/handlers/pointcloud_handler.hpp
@@ -75,9 +75,21 @@ public:
 
     // Create the point cloud, convert the ROS message, and save it
     if (has_intensity) {
-      pcl::PointCloud<NebulaPoint>::Ptr cloud(new pcl::PointCloud<NebulaPoint>);
-      pcl::fromROSMsg(pc2_msg, *cloud);
-      return save_pointcloud_to_file<NebulaPoint>(cloud, data_meta.data_path);
+      pcl::PointCloud<NebulaPoint>::Ptr cloud_nebula(new pcl::PointCloud<NebulaPoint>);
+      pcl::fromROSMsg(pc2_msg, *cloud_nebula);
+
+      // Convert NebulaPoint to pcl::PointXYZI for better compatibility with PCD format
+      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_xyzi(new pcl::PointCloud<pcl::PointXYZI>);
+      cloud_xyzi->header = cloud_nebula->header;
+      cloud_xyzi->width = cloud_nebula->width;
+      cloud_xyzi->height = cloud_nebula->height;
+      cloud_xyzi->is_dense = cloud_nebula->is_dense;
+      cloud_xyzi->points.resize(cloud_nebula->points.size());
+      for (size_t i = 0; i < cloud_nebula->points.size(); ++i) {
+        cloud_xyzi->points[i] = convert_nebula_to_xyzi(cloud_nebula->points[i]);
+      }
+
+      return save_pointcloud_to_file<pcl::PointXYZI>(cloud_xyzi, data_meta.data_path);
     } else {
       throw std::invalid_argument("The pointcloud message should have an 'intensity' field!");
     }
@@ -87,6 +99,16 @@ private:
   std::string topic_dir_;
 
   std::vector<sensor_msgs::msg::PointCloud2> data_vec_;
+
+  pcl::PointXYZI convert_nebula_to_xyzi(const NebulaPoint & nebula_point)
+  {
+    pcl::PointXYZI point;
+    point.x = nebula_point.x;
+    point.y = nebula_point.y;
+    point.z = nebula_point.z;
+    point.intensity = static_cast<float>(nebula_point.intensity);
+    return point;
+  }
 
   // Templated function to save a point cloud to file
   template <typename PointT>

--- a/ros2_bag_exporter/include/rosbag2_exporter/point_types.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/point_types.hpp
@@ -1,0 +1,39 @@
+#ifndef ROSBAG2_EXPORTER__POINT_TYPES_HPP_
+#define ROSBAG2_EXPORTER__POINT_TYPES_HPP_
+
+#include <pcl/point_types.h>
+
+namespace rosbag2_exporter
+{
+
+/**
+ * Pointcloud data structure used by Nebula HESAI Lidar
+ *  ROS driver.
+ */
+
+struct PointXYZIRCAEDT
+{
+  float x;
+  float y;
+  float z;
+  std::uint8_t intensity;
+  std::uint8_t return_type;
+  std::uint16_t channel;
+  float azimuth;
+  float elevation;
+  float distance;
+  std::uint32_t time_stamp;
+};
+
+using NebulaPoint = PointXYZIRCAEDT;
+
+}  // namespace rosbag2_exporter
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+  rosbag2_exporter::PointXYZIRCAEDT,
+  (float, x, x)(float, y, y)(float, z, z)(std::uint8_t, intensity, intensity)(
+    std::uint8_t, return_type,
+    return_type)(std::uint16_t, channel, channel)(float, azimuth, azimuth)(
+    float, elevation, elevation)(float, distance, distance)(std::uint32_t, time_stamp, time_stamp))
+
+#endif  // ROSBAG2_EXPORTER__POINT_TYPES_HPP_

--- a/runtime.sh
+++ b/runtime.sh
@@ -112,6 +112,7 @@ docker run -it --rm --net host --privileged \
     -v /dev:/dev \
     -v /tmp:/tmp \
     $CYCLONE_VOL \
+    -v $SCRIPT_DIR/ros2_bag_exporter/config:/opt/ros_ws/config \
     -v $ROSBAGS_DIR:/opt/ros_ws/rosbags \
     -v $EXPORT_DIR:/opt/ros_ws/exported_data \
     -v /etc/localtime:/etc/localtime:ro \


### PR DESCRIPTION
- Define `PointXYZIRCAEDT` point data structure and register it
  with the PCL point cloud library in a new header file.
  - Use `NebulaPoint` as an alias for `PointXYZIRCAEDT`
  - Cast `NebulaPoint` to pcl::PointXYZI before saving
    - Iterate through the points in the original NebulaPoint cloud
       and assign the values to a new point cloud with `pcl::PointXYZI`
       structure.
- Update `pointcloud_handler.hpp` to use `NebulaPoint` when
  handling point clouds.
- Allow the user to define a directory for exported data
  - Modify `dev.sh` and `runtime.sh` to include `-o | --output` option to
    specify the export directory.
- Mount config files when running the runtime Docker
  - Modify `runtime.sh` to mount  `ros2_bag_exporter/config` in `/opt/ros_ws/config`
- Update README
 - Provide instructions for running the Docker container and the
  `ros2_bag_exporter bag_exporter` ROS node