### PR TITLE
Fix camera-lidar timestamp synchronisation

### DIFF
--- a/ros2_bag_exporter/config/av_sensor_export_config.yaml
+++ b/ros2_bag_exporter/config/av_sensor_export_config.yaml
@@ -14,6 +14,7 @@ topics:
   - name: "/sensor/camera/fsp_l/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 70
     topic_dir: "camera/fsp_l"
 
   - name: "/sensor/camera/fsp_l/camera_info"
@@ -24,6 +25,7 @@ topics:
   - name: "/sensor/camera/fsp_r/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 70
     topic_dir: "camera/fsp_r"
 
   - name: "/sensor/camera/fsp_r/camera_info"
@@ -34,6 +36,7 @@ topics:
   - name: "/sensor/camera/rsp_l/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 20
     topic_dir: "camera/rsp_l"
 
   - name: "/sensor/camera/rsp_l/camera_info"
@@ -44,6 +47,7 @@ topics:
   - name: "/sensor/camera/rsp_r/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 20
     topic_dir: "camera/rsp_r"
 
   - name: "/sensor/camera/rsp_r/camera_info"
@@ -54,6 +58,7 @@ topics:
   - name: "/sensor/camera/lspf_r/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 51
     topic_dir: "camera/lspf_r"
 
   - name: "/sensor/camera/lspf_r/camera_info"
@@ -64,6 +69,7 @@ topics:
   - name: "/sensor/camera/lspr_l/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 38
     topic_dir: "camera/lspr_l"
 
   - name: "/sensor/camera/lspr_l/camera_info"
@@ -74,6 +80,7 @@ topics:
   - name: "/sensor/camera/rspf_l/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 88
     topic_dir: "camera/rspf_l"
 
   - name: "/sensor/camera/rspf_l/camera_info"
@@ -84,6 +91,7 @@ topics:
   - name: "/sensor/camera/rspr_r/image_rect_color/compressed"
     type: "CompressedImage"
     sample_interval: 1
+    timestamp_offset_ms: 101
     topic_dir: "camera/rspr_r"
 
   - name: "/sensor/camera/rspr_r/camera_info"

--- a/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/bag_exporter.hpp
@@ -42,6 +42,7 @@ struct TopicConfig
   std::string encoding;
   int sample_interval;
   std::string topic_dir;
+  uint16_t timestamp_offset_ms;
 };
 
 struct Handler

--- a/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
+++ b/ros2_bag_exporter/include/rosbag2_exporter/utils.hpp
@@ -45,12 +45,14 @@ int64_t toNanoseconds(const builtin_interfaces::msg::Time & timestamp)
   return static_cast<int64_t>(timestamp.sec) * std::pow(10, 9) + timestamp.nanosec;
 }
 
-// Function to find the closest index in a sorted vector for a given timestamp
+// Find the index of the closest data timestamp to a target timestamp
 size_t find_closest_timestamp(
-  const std::vector<DataMeta> & target_vector, const builtin_interfaces::msg::Time & timestamp,
-  size_t & last_index)
+  const std::vector<DataMeta> & target_vector, uint16_t timestamp_offset_ms,
+  const builtin_interfaces::msg::Time & target_timestamp, size_t & last_index)
 {
-  int64_t timestamp_ns = toNanoseconds(timestamp);
+  // Apply the timestamp offset to the target timestamp
+  int64_t timestamp_offset_ns = static_cast<int64_t>(timestamp_offset_ms) * 1'000'000;
+  int64_t target_timestamp_ns = toNanoseconds(target_timestamp) + timestamp_offset_ns;
 
   // Start from the last known index
   size_t closest_index = last_index;
@@ -59,7 +61,7 @@ size_t find_closest_timestamp(
   // Iterate forward through the sorted vector
   for (size_t i = last_index; i < target_vector.size(); ++i) {
     int64_t target_ns = toNanoseconds(target_vector[i].timestamp);
-    int64_t diff = std::abs(target_ns - timestamp_ns);
+    int64_t diff = std::abs(target_ns - target_timestamp_ns);
 
     // Update closest index and minimum difference
     if (diff < min_diff) {

--- a/ros2_bag_exporter/src/bag_exporter.cpp
+++ b/ros2_bag_exporter/src/bag_exporter.cpp
@@ -49,10 +49,36 @@ void BagExporter::load_configuration()
       tc.type = MessageType::PointCloud2;
     } else if (type == "Image") {
       tc.type = MessageType::Image;
-      tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8";
+
+      if (topic["encoding"]) {
+        tc.encoding = topic["encoding"].as<std::string>();
+      } else {
+        // Default encoding if not specified
+        tc.encoding = "rgb8";
+      }
+
+      if (topic["timestamp_offset_ms"]) {
+        tc.timestamp_offset_ms = topic["timestamp_offset_ms"].as<uint16_t>();
+      } else {
+        // Default offset if not specified
+        tc.timestamp_offset_ms = 0;
+      }
     } else if (type == "CompressedImage") {
       tc.type = MessageType::CompressedImage;
-      tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8";
+
+      if (topic["encoding"]) {
+        tc.encoding = topic["encoding"].as<std::string>();
+      } else {
+        // Default encoding if not specified
+        tc.encoding = "rgb8";
+      }
+
+      if (topic["timestamp_offset_ms"]) {
+        tc.timestamp_offset_ms = topic["timestamp_offset_ms"].as<uint16_t>();
+      } else {
+        // Default offset if not specified
+        tc.timestamp_offset_ms = 0;
+      }
     } else if (type == "CameraInfo") {
       tc.type = MessageType::CameraInfo;
     } else if (type == "IMU") {
@@ -304,8 +330,9 @@ void BagExporter::export_data(const fs::path & used_rosbag, const fs::path & out
       // Get current camera metadata
       auto & curr_cam_handler = handlers_[topics_[k].name].handler;
       auto & current_meta_data_vec = curr_cam_handler->data_meta_vec_;
-      size_t closest_time_index =
-        utils::find_closest_timestamp(current_meta_data_vec, curr_lidar_time, msg_index[k]);
+      auto & camera_timestamp_offset_ms = topics_[k].timestamp_offset_ms;
+      size_t closest_time_index = utils::find_closest_timestamp(
+        current_meta_data_vec, camera_timestamp_offset_ms, curr_lidar_time, msg_index[k]);
 
       // Create YAML metadata based on the found time index
       auto current_cam_meta = current_meta_data_vec[closest_time_index];


### PR DESCRIPTION
- Add `timestamp_offset_ms` parameter for every camera to adjust
  lidar timestamps to correlate correctly with camera data.
  - Update `find_closest_timestamp` function to receive this parameter
    and apply the time offset required for each camera.